### PR TITLE
Fixes powerarrow theme broken due to [[ nesting

### DIFF
--- a/themes/powerarrow/theme.lua
+++ b/themes/powerarrow/theme.lua
@@ -328,7 +328,7 @@ function theme.at_screen_connect(s)
             layout = wibox.layout.fixed.horizontal,
             wibox.widget.systray(),
             wibox.container.margin(scissors, 4, 8),
-            --[[[[ using shapes
+            --[[ using shapes
             pl(wibox.widget { mpdicon, theme.mpd.widget, layout = wibox.layout.align.horizontal }, "#343434"),
             pl(task, "#343434"),
             --pl(wibox.widget { mailicon, mail and mail.widget, layout = wibox.layout.align.horizontal }, "#343434"),


### PR DESCRIPTION
One comment was using [[[[, making the lua parser crash at loading of
the theme.